### PR TITLE
Fix TypeError for slot

### DIFF
--- a/ping-thing-client.mjs
+++ b/ping-thing-client.mjs
@@ -213,6 +213,13 @@ async function pingThing() {
           commitment: COMMITMENT_LEVEL,
           maxSupportedTransactionVersion: 255,
         });
+        if (txLanded === null) {
+          console.log(
+            signature,
+            `${new Date().toISOString()} ERROR: tx is not landed in ${SLEEP_MS_RPC}ms. Not sending to VA.`,
+          );
+          continue;
+        }
         slotLanded = txLanded.slot;
       }
 
@@ -222,7 +229,6 @@ async function pingThing() {
           signature,
           `${new Date().toISOString()} ERROR: Slot ${slotLanded} < ${slotSent}. Not sending to VA.`,
         );
-        slotLanded = null;
         continue;
       }
 


### PR DESCRIPTION
Error:
```
2023-12-14T12:59:46.452Z ERROR: TypeError
2023-12-14T12:59:46.452Z ERROR: Cannot read properties of null (reading 'slot')
```

`getTransaction` can return `null`, we need to add an additional check
https://solana-labs.github.io/solana-web3.js/classes/Connection.html#getTransaction